### PR TITLE
Add document about django-decouple and django-heroku into installation instructions and add default values for the variables that use of decouple.config().

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,49 +36,25 @@
     ```
     For more information: https://www.djangoproject.com/
 
+- **python-decouple**
+    ```bash
+    $ pip install python-decouple
+    ```
+    For more information: https://pypi.org/project/python-decouple/
+
+- **Django-Heroku** package
+    ```bash
+    $ pip install django-heroku
+    ```
+    For more information: https://pypi.org/project/django-heroku/
+
 
 **To install and run locally**
 1. Clone project from [KhubKhao-Recommender](https://github.com/NokKbl/khubkhao-recommender.git).
-2. Edit `settings.py` file.
-    1. Remove/comment these lines in the file.
-        ```python
-        import django_heroku
-        from decouple import config
-        ```
-    2. Add `127.0.0.1` to `ALLOWED_HOSTS`.
-        ```python
-        ALLOWED_HOSTS = ['.herokuapp.com', '.localhost','127.0.0.1']
-        ```
-    3. Scroll down to `DATABASES` and change from using `PostgreSQL` as a database
-        ```python
-        DATABASES = {
-            'default': {
-                'ENGINE': 'django.db.backends.postgresql',
-                'NAME': 'khubkhao_db',
-                'USER': config('KKR_USER_DB'),
-                'PASSWORD': config('KKR_PWD_DB'),
-                'HOST': config('KKR_HOST_DB'),
-                'PORT': '5432',
-            }
-        }
-        ```
-        into `SQLite`.
-        ```python
-        DATABASES = {
-            'default': {
-                'ENGINE': 'django.db.backends.sqlite3',
-                'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-                }
-        }
-        ```
-    4. Scroll to the bottom of the file then remove.
-        ```python
-        django_heroku.settings(locals())
-        ```
-        and put the code below instead.
-        ```python
-        STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
-        ```
+2. Install all required software in `requirements.txt` file.
+    ```bash
+    $ pip install -r requirements.txt
+    ```
 3. Open Terminal and run commands below.
     1. Make migrations.
         ```bash

--- a/khubkhaoRec/settings.py
+++ b/khubkhaoRec/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = 'a7qia@rzah#6fxtg7!iru40!7@ut&hfupm268_thcsd&^!_z6v'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['.herokuapp.com', '.localhost']
+ALLOWED_HOSTS = ['.herokuapp.com', '.localhost', '127.0.0.1']
 
 # Application definition
 
@@ -79,10 +79,10 @@ WSGI_APPLICATION = 'khubkhaoRec.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'khubkhao_db',
-        'USER': config('KKR_USER_DB'),
-        'PASSWORD': config('KKR_PWD_DB'),
-        'HOST': config('KKR_HOST_DB'),
+        'NAME': config('KKR_NAME_DB', default='khubkhao_local_db'),
+        'USER': config('KKR_USER_DB', default='localUser'),
+        'PASSWORD': config('KKR_PWD_DB', default='local123'),
+        'HOST': config('KKR_HOST_DB', default='35.240.165.203'),
         'PORT': '5432',
     }
 }
@@ -131,4 +131,5 @@ STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
+# Activate Django-Heroku.
 django_heroku.settings(locals())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ psycopg2-binary
 python-decouple
 Django==2.1.2
 gunicorn==19.9.0
-whitenoise==4.1


### PR DESCRIPTION
- Add `django-decouple` and `django-heroku` into required software.
- Add default values for the variables that use of decouple.config().
- Improve some installation instructions.